### PR TITLE
fix (swish-e) : maj des depots de debian 10

### DIFF
--- a/images/documentation-gm-swish-e/Dockerfile
+++ b/images/documentation-gm-swish-e/Dockerfile
@@ -1,5 +1,10 @@
 FROM abesesr/swish-e-docker:1.1.1
 
+# Les depots de debian 10 Buster ont migré dans archive
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+
 RUN apt-get update && apt-get -y install cron
 
 # Copy swish-e-cron file to the cron.d directory


### PR DESCRIPTION
Problème lors de la construction de l'image de swish-e.
Les dépôts de la Debian 10 Buster ont migrés vers les dépôts d'archivages. 